### PR TITLE
Align daily info layout

### DIFF
--- a/css/page-home.css
+++ b/css/page-home.css
@@ -23,16 +23,21 @@ header#masthead.sheader { z-index: 999; }
     box-sizing: border-box;
 }
 
-#daily-info-container { text-align: center; }
+#daily-info-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+}
 #daily-info-title {
     margin: 0;
-    font-size: 1.6rem;
+    font-size: 1.3rem;
     font-weight: bold;
     font-family: 'Superclarendon', serif;
     color: #e6e0f3;
 }
 #daily-info-date {
-    margin: 5px 0 25px 0;
+    margin: 0;
     font-size: 1.1rem;
     font-family: sans-serif;
     color: #e6e0f3;
@@ -171,8 +176,8 @@ header#masthead.sheader { z-index: 999; }
     .pope-section-container, #intro-grid-container { gap: 10px; row-gap: 20px; }
     .icon-grid-item, .grid-erb { height: 80px; }
     .grid-item-label { font-size: 0.8rem; margin-top: 5px; }
-    #daily-info-title { font-size: 1.4rem; }
-    #daily-info-date { font-size: 1rem; }
+    #daily-info-title { font-size: 1.1rem; }
+    #daily-info-date { font-size: 0.9rem; }
 }
 
 /* === MINIMALISTICKÝ DVOUŘÁDKOVÝ PŘEHRÁVAČ v3.1 (beze změny) === */

--- a/page-home.php
+++ b/page-home.php
@@ -79,8 +79,8 @@ foreach ($grid_items as $item) {
             
             <?php if (!empty($nazev_dne) || !empty($datum_dne)): ?>
                 <div id="daily-info-container">
-                    <?php if (!empty($nazev_dne)): ?><h2 id="daily-info-title"><?php echo esc_html($nazev_dne); ?></h2><?php endif; ?>
-                    <?php if (!empty($datum_dne)): ?><p id="daily-info-date"><?php echo esc_html($datum_dne); ?></p><?php endif; ?>
+                    <?php if (!empty($nazev_dne)): ?><h2 id="daily-info-title" class="daily-info-item"><?php echo esc_html($nazev_dne); ?></h2><?php endif; ?>
+                    <?php if (!empty($datum_dne)): ?><p id="daily-info-date" class="daily-info-item"><?php echo esc_html($datum_dne); ?></p><?php endif; ?>
                 </div>
             <?php endif; ?>
             


### PR DESCRIPTION
## Summary
- update daily info flexbox layout in `page-home.css`
- adjust title and date font sizes
- add responsive tweaks for small screens
- add shared class to daily info elements

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68678cc2a2ac8322b584494d133feace